### PR TITLE
Fix control and body builder

### DIFF
--- a/irsl_choreonoid/RobotBuilder.py
+++ b/irsl_choreonoid/RobotBuilder.py
@@ -292,7 +292,7 @@ class RobotBuilder(object):
             name='LINK_{}'.format(len(self.created_links))
         #groot=self.__di.target
         #hasattr(rb.draw, 'SgPosTransform' )
-        groot=cutil.SgPosTransform(self.__di.SgPosTransform)
+        groot=self.__di.SgPosTransform.clone()
         res = RobotBuilder.searchSceneGraph(groot, 'joint_root')
         if len(res) == 0:
             if root:
@@ -560,38 +560,47 @@ class RobotBuilder(object):
         if shape is not None:
             ## clone
             if type(shape) is cutil.SgGroup:
-                shape = cutil.SgGroup(shape)
+                ##shape = cutil.SgGroup(shape)
+                shape = shape.clone()
             elif type(shape) is cutil.SgPosTransform:
-                shape = cutil.SgPosTransform(shape)
+                ##shape = cutil.SgPosTransform(shape)
+                shape = shape.clone()
             else:
                 print('Invalid type?? shape: {}, type: {}'.format(shape, type(shape)))
                 tmp = cutil.SgGroup()
                 tmp.addChild(shape)
-                shape = cutil.SgGroup(tmp)
+                #shape = cutil.SgGroup(tmp)
+                shape = tmp.clone()
             baselk.addShapeNode(shape)
         if visual is not None:
             ## clone
             if type(visual) is cutil.SgGroup:
-                visual = cutil.SgGroup(visual)
+                #visual = cutil.SgGroup(visual)
+                visual = visual.clone()
             elif type(visual) is cutil.SgPosTransform:
-                visual = cutil.SgPosTransform(visual)
+                #visual = cutil.SgPosTransform(visual)
+                visual = visual.clone()
             else:
                 print('Invalid type?? visual: {}, type: {}'.format(visual, type(visual)))
                 tmp = cutil.SgGroup()
                 tmp.addChild(visual)
-                visual = cutil.SgGroup(tmp)
+                #visual = cutil.SgGroup(tmp)
+                visual = tmp.clone()
             baselk.addVisualShapeNode(visual)
         if collision is not None:
             ## clone
             if type(collision) is cutil.SgGroup:
-                collision = cutil.SgGroup(collision)
+                #collision = cutil.SgGroup(collision)
+                collision = collision.clone()
             elif type(collision) is cutil.SgPosTransform:
-                collision = cutil.SgPosTransform(collision)
+                #collision = cutil.SgPosTransform(collision)
+                collision = collision.clone()
             else:
                 print('Invalid type?? collision: {}, type: {}'.format(collision, type(collision)))
                 tmp = cutil.SgGroup()
                 tmp.addChild(collision)
-                collision = cutil.SgGroup(tmp)
+                #collision = cutil.SgGroup(tmp)
+                collision = tmp.clone()
             baselk.addCollisionShapeNode(collision)
         self.created_links.append(baselk)
         return baselk

--- a/irsl_choreonoid/control_utils.py
+++ b/irsl_choreonoid/control_utils.py
@@ -225,11 +225,11 @@ class Sequencer(object):
             angle_vector ( numpy.array ) : Target angle-vector
             step (int, default=2) : After step cycle, target-angles equals to angle_vector
         """
-        if self.prev_angle_vec is not None:
-            self._appendAngles(angle_vector)
+        if self.prev_angle_vec is None:
+            self.setNoInterpolation( [angle_vector] )
         else:
             mat = np.array( [(self.prev_angle_vec + angle_vector)*0.5, angle_vector] )
-            self.sequence = at.transpose().tolist()
+            self.sequence = mat.transpose().tolist()
     ## def insert(self),###
     def pop(self):
         if len(self.sequence[0]) == 0:


### PR DESCRIPTION
This pull request includes changes to the `irsl_choreonoid` package, specifically focusing on improving object cloning and fixing a bug in angle vector handling. The most important changes are as follows:

Improvements to object cloning:

* [`irsl_choreonoid/RobotBuilder.py`](diffhunk://#diff-be6e08caf1d2591ca5c5ba6e5896668d74d38639ef4216f39aecd41456402b61L295-R295): Replaced direct instantiation of `cutil.SgPosTransform` and `cutil.SgGroup` with their `clone` method to ensure proper cloning of objects. This change affects the `createLinkFromShape` and `createLinkBase` methods. [[1]](diffhunk://#diff-be6e08caf1d2591ca5c5ba6e5896668d74d38639ef4216f39aecd41456402b61L295-R295) [[2]](diffhunk://#diff-be6e08caf1d2591ca5c5ba6e5896668d74d38639ef4216f39aecd41456402b61L563-R603)

Bug fix in angle vector handling:

* [`irsl_choreonoid/control_utils.py`](diffhunk://#diff-b49ff12ef717f89df36d2caede09f9f6af9829ee9411ad76aa95afc92bd0954fL228-R232): Fixed a bug in the `setWithSteps` method by ensuring that the `sequence` is set correctly when `prev_angle_vec` is `None`. This prevents errors during angle interpolation.