### PR TITLE
add some functions

### DIFF
--- a/irsl_choreonoid/make_shapes.py
+++ b/irsl_choreonoid/make_shapes.py
@@ -746,6 +746,32 @@ def makeTetrahedron(base_width, base_height, height, base_center=None, center_x=
     mf.generateNormals(mesh, 1.57, False)
     return __genShape(mesh, wrapped=wrapped, rawShape=rawShape, coords=coords, **kwargs)
 
+def makeTriangles(vertices, indices=None, wrapped=True, rawShape=False, coords=None, **kwargs):
+    """Making 'Raw Triangle Mesh' shape
+
+    Args:
+        vertices (numpy.array) : N x 3 matrix (N is number of vertices) or list[numpy.array]
+        indices (list[int], optional) : size of this list should be M x 3 (M is number of faces)
+        wrapped (boolean, default = True) : If True, the loaded scene is wrapped by irsl_choreonoid.irsl_draw_object.coordsWrapper
+        rawShape (boolean, default = False) : If True, instance of cnoid.Util.SgShape will be returned (ignore wrapped)
+        coords (cnoid.IRSLCoords.coordinates, optional) :
+        kwargs ( dict[str, param] ) : Keywords for generating material and mesh
+
+    Returns:
+        cnoid.Util.SgPosTransform or irsl_choreonoid.irsl_draw_object.coordsWrapper : Created object as a node of SceneGraph or wrapped class for interactive programming
+
+    """
+    mesh = cutil.SgMesh()
+    vt = npa(vertices, dtype='float32')
+    if indices is None:
+        size = vt.shape[0]//3
+        indices = list(range(size*3))
+    mesh.setVertices(vt)
+    mesh.setFaceVertexIndices(indices)
+    mf = cutil.MeshFilter()
+    mf.generateNormals(mesh, 1.57, False)
+    return __genShape(mesh, wrapped=wrapped, rawShape=rawShape, coords=coords, **kwargs)
+
 ### utility functions
 def makeAxis(radius=0.075, length=1.0, axisLength=0.35, axisRadius=0.125, axisRatio=None, color=None, scale=None, coords=None, wrapped=True, **kwargs):
     """Makeing single axis shape using cylinder and cone

--- a/pybind11/PyIRSLCoords.cpp
+++ b/pybind11/PyIRSLCoords.cpp
@@ -10,6 +10,8 @@
 #include <cnoid/PyEigenTypes>
 #include <cnoid/Body>
 #include <cnoid/Link>
+// for computeRotationScaling
+#include <Eigen/SVD>
 
 typedef Eigen::Ref<Matrix4RM> ref_noconst_mat4;
 typedef Eigen::Ref<Matrix3RM> ref_noconst_mat3;
@@ -67,6 +69,23 @@ PYBIND11_MODULE(IRSLCoords, m)
                 if (!eps_eq(*aptr++, *bptr++, eps)) return false;
             }
             return true; }, py::arg("a"), py::arg("b"), py::arg("eps") = 0.00001);
+
+    m.def("computeRotationScaling", [] (ref_mat3 affine) {
+        Eigen::Affine3d af;
+        af.matrix()(0, 0) = affine(0, 0);
+        af.matrix()(0, 1) = affine(0, 1);
+        af.matrix()(0, 2) = affine(0, 2);
+        af.matrix()(1, 0) = affine(1, 0);
+        af.matrix()(1, 1) = affine(1, 1);
+        af.matrix()(1, 2) = affine(1, 2);
+        af.matrix()(2, 0) = affine(2, 0);
+        af.matrix()(2, 1) = affine(2, 1);
+        af.matrix()(2, 2) = affine(2, 2);
+        //Eigen::Matrix3d rot, scl;
+        std::vector<Matrix3RM> res(2);
+        af.computeRotationScaling(&(res[0]), &(res[1]));
+        return res;
+    });
 
     /// for cnoid::Position
     m.def("PositionInverse", [](ref_mat4 _position) -> Matrix4RM { cnoidPosition p(_position); return p.inverse().matrix(); }, R"__IRSL__(


### PR DESCRIPTION
This pull request introduces a new shape creation utility and exposes a useful transformation decomposition function to Python bindings. The main changes are the addition of a `makeTriangles` function for creating raw triangle meshes and the exposure of `computeRotationScaling` via pybind11, which allows users to decompose an affine transformation matrix into rotation and scaling components.

**Shape creation utilities:**

* Added the `makeTriangles` function to `make_shapes.py`, enabling the creation of raw triangle mesh shapes from a set of vertices and optional face indices. This function supports both wrapped and raw shape outputs for flexible usage.

**Python bindings enhancements:**

* Exposed the `computeRotationScaling` function in `PyIRSLCoords.cpp`, allowing Python users to decompose a 3x3 affine matrix into its rotation and scaling components using Eigen's SVD-based method.
* Included the necessary Eigen SVD header in `PyIRSLCoords.cpp` to support the new decomposition functionality.